### PR TITLE
doc: Link to source code and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,17 @@
 # MATE
 
-See the documentation in [`doc/`](./doc/), which is published to https://mate.galois.com/ by CI.
+<!-- 
+The following paragraph is duplicated in doc/index.rst and doc/overview.rst;
+updates to one should be reflected in the other(s).
+-->
 
-Places to start:
+MATE is a suite of tools for interactive program analysis with a focus on
+hunting for bugs in C and C++ code. MATE unifies application-specific and
+low-level vulnerability analysis using code property graphs (CPGs), enabling the
+discovery of highly application-specific vulnerabilities that depend on both
+implementation details and the high-level semantics of target C/C++ programs.
 
-- [MATE User Workflow](https://mate.galois.com/master/user-workflow.html) (built from [doc/user-workflow.rst](doc/user-workflow.rst))
-- [MATE System Overview](https://mate.galois.com/master/overview.html) (built from [doc/overview.rst](doc/overview.rst))
-- If you are a developer of MATE: [Hacking on MATE](https://mate.galois.com/master/hacking.html) (built from [doc/hacking.rst](doc/hacking.rst))
+See [the online documentation][docs] for more information.
 
 ## Acknowledgements
 
@@ -16,3 +21,5 @@ Contract No. FA8750-19-C-0004. Any opinions, findings and conclusions or
 recommendations expressed in this material are those of the author(s) and do
 not necessarily reflect the views of the United States Air Force or DARPA.
 Approved for Public Release, Distribution Unlimited.
+
+[docs]: https://galoisinc.github.io/MATE/

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,6 +1,10 @@
 MATE: Merged Analysis To prevent Exploits
 =========================================
 
+..
+   The following paragraph is duplicated in ../README.md and overview.rst;
+   updates to one should be reflected in the other(s).
+
 MATE is a suite of tools for interactive program analysis with a focus on
 hunting for bugs in C and C++ code. MATE unifies application-specific and
 low-level vulnerability analysis using code property graphs (CPGs), enabling the

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -8,6 +8,10 @@ Overview
   This page provides a high-level overview of MATE. To get started using MATE
   right away, see :doc:`quickstart`.
 
+..
+   The following paragraph is duplicated in ../README.md and index.rst;
+   updates to one should be reflected in the other(s).
+
 MATE is a suite of tools for interactive program analysis with a focus on
 hunting for bugs in C and C++ code. MATE unifies application-specific and
 low-level vulnerability analysis using code property graphs (CPGs), enabling the


### PR DESCRIPTION
When going to the webpage, it's not immediately clear where to find the source. Also, when viewing the RST files in the repo, it's not clear that you can also view them online in HTML.