### PR TITLE
Update cclyzer++ to v0.5.0

### DIFF
--- a/frontend/mate-common/mate_common/models/builds.py
+++ b/frontend/mate-common/mate_common/models/builds.py
@@ -23,7 +23,6 @@ class PointerAnalysis(str, enum.Enum):
     """
 
     DEBUG = "debug"
-    SUBSET_AND_UNIFICATION = "subset-and-unification"
     SUBSET = "subset"
     UNIFICATION = "unification"
 

--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -35,7 +35,10 @@ find_program(
   NAMES "clang-format"
   DOC "Path to clang-format executable.")
 
+# cclyzer++ builds against LLVM 11 by default, override this.
+set(LLVM_MAJOR_VERSION 10)
 add_subdirectory(PointerAnalysis)
+
 add_subdirectory(MATE)
 add_subdirectory(headache)
 add_subdirectory(nomina)


### PR DESCRIPTION
Suggestions for review, from high level to low level:

- My thousand-foot summary:
  - Remove `subset-and-unification`: Faster builds!
  - LLVM 11 compatibility, need to specify LLVM 10 in CMake
  - More refactoring of Datalog code
- [The changelog](https://galoisinc.github.io/cclyzerpp/changelog.html)
- [The list of merged MRs since v0.3](https://github.com/GaloisInc/cclyzerpp/pulls?q=is%3Apr+is%3Aclosed+created%3A%3E2022-10-13T11%3A51+)
- [The list of commits and diff from v0.3 to v0.5.0](https://github.com/GaloisInc/cclyzerpp/compare/v0.3...v0.5.0)

Golden tests did change in the LLVM 10 -> 11 upgrade, I reviewed them myself in https://github.com/GaloisInc/cclyzerpp/pull/93.

The test suite is passing.